### PR TITLE
Add touch drag-and-drop support

### DIFF
--- a/style.css
+++ b/style.css
@@ -63,6 +63,14 @@ h1 {
   width: 80px;
   cursor: grab;
   user-select: none;
+  touch-action: none;
+}
+
+.draggable-wrapper.dragging {
+  position: fixed;
+  z-index: 1000;
+  pointer-events: none;
+  touch-action: none;
 }
 
 .draggable-img {


### PR DESCRIPTION
## Summary
- support touch-based drag-and-drop using pointer events
- keep elements from scrolling while dragging

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_685ff127a2c0832e8ab1643773c0f837