### PR TITLE
Fix iPad drag preview sizing

### DIFF
--- a/script.js
+++ b/script.js
@@ -32,6 +32,11 @@ function setupDraggables() {
         wrapper.querySelector('.drop-zone').contains(draggedItem)
       );
 
+      // Ensure preview size is consistent when dragging from a drop zone
+      if (originZoneWrapper) {
+        restoreDraggable(draggedItem);
+      }
+
       setTimeout(() => {
         item.style.display = 'none';
       }, 0);
@@ -51,6 +56,10 @@ function setupDraggables() {
       originZoneWrapper = [...document.querySelectorAll('.drop-zone-wrapper')].find(wrapper =>
         wrapper.querySelector('.drop-zone').contains(draggedItem)
       );
+
+      if (originZoneWrapper) {
+        restoreDraggable(draggedItem);
+      }
 
       const rect = item.getBoundingClientRect();
       const offsetX = e.clientX - rect.left;


### PR DESCRIPTION
## Summary
- normalize item size when dragging from a drop zone
- ensure touch dragging also resets the item to default size

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68600ab7a6cc832ebd966dff2ea6d9f6